### PR TITLE
[WIP] Binary Creation Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ TODO
 
 * Build a GUI frontend
 * Setup a travis build system
-* CodeClimate for code coverage?
 * Setup a unit testing suite (will have to look for one)
 * use `nwjs-builder` to create a proper binaries
 * create a `for-contributors.md` for, well, contributors

--- a/binary-creation/.gitignore
+++ b/binary-creation/.gitignore
@@ -1,0 +1,5 @@
+
+cache/
+build/
+
+node_modules/

--- a/binary-creation/README.md
+++ b/binary-creation/README.md
@@ -1,0 +1,26 @@
+# Binary Creation sub-folder
+
+This is used to create the various distributable binaries for cross-platform support.
+
+First install `nw-builder` globally by running
+
+```
+npm install nw-builder -g
+```
+
+To actually build all platform versions, use
+
+```
+npm build.js
+```
+
+
+Built binaries are present in the `build` folder.
+
+TODO
+====
+
+Write a script that auto-generates build for tagged releases, with a changelog pulled
+from a known file. Also uploads this to github.
+
+Use the [Github Releases API](https://developer.github.com/v3/repos/releases/) to do this.

--- a/binary-creation/build.js
+++ b/binary-creation/build.js
@@ -1,0 +1,17 @@
+var NwBuilder = require('nw-builder');
+var nw = new NwBuilder({
+    files: '../**/**', // use the glob format
+    platforms: ['osx32', 'osx64', 'win32', 'win64', 'linux32', 'linux64'],
+    version: '0.12.3'
+});
+
+//Log stuff you want
+
+nw.on('log', console.log);
+
+// Build returns a promise
+nw.build().then(function() {
+    console.log('all done!');
+}).catch(function(error) {
+    console.error(error);
+});

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "Loginion",
-  "main": "index.html",
-  "dependencies": {
-    "font-awesome": "^4.5.0",
-    "jquery": "^2.2.0",
-    "querystring": "^0.2.0",
-    "request": "^2.67.0"
-  },
-  "repository": "https://github.com/hawklings/loginion",
-  "LICENSE": "MIT"
+    "name": "Loginion",
+    "version": "0.0.1",
+    "main": "index.html",
+    "dependencies": {
+        "font-awesome": "^4.5.0",
+        "jquery": "^2.2.0",
+        "querystring": "^0.2.0",
+        "request": "^2.67.0"
+    },
+    "repository": "https://github.com/hawklings/loginion",
+    "LICENSE": "MIT"
 }


### PR DESCRIPTION
Working on creating distributable binaries for all platforms (windows, OS X(32|64), linux(32|64)).

Do not merge, work in progress
## Checklist
- [ ] use `nw-builder` to create build files
- [ ] `zip` the generated files automatically
- [ ] upload releases automatically to github downloads with the API
- [ ] Install script for linux, Windows? (OSX is just drag-and-drop)
- [ ] automate the process of creating a new release
- [ ] allow Travis to build for all platforms (this may need container-based builds to be fast)
